### PR TITLE
Add simpson specific END line to output

### DIFF
--- a/dynamic_quad_lineshape.cpp
+++ b/dynamic_quad_lineshape.cpp
@@ -250,6 +250,7 @@ int main()
     for(i=0;i<np;i++){
         fprintf(fp,"%f %f\n",real(total_FID(i)),imag(total_FID(i)));
     }
+    fprintf(fp,"%s","END");
     fclose(fp);
 
     //writing the spectrum as a SPE file
@@ -267,7 +268,7 @@ int main()
         fprintf(fp,"%f %f\n",real(spectrum(i)),imag(spectrum(i)));
         k++;
     }
-
+    fprintf(fp,"%s","END");
     fclose(fp);
     return 0;
 }


### PR DESCRIPTION
The SIMPSON output files require a DATA before and an END (without trailing space or \n) at the end of the file. I'm not sure about the frequency convention, but i think the *.spe file has the wrong order of frequencies (mirrored).